### PR TITLE
Simple fix concenring cancel/end print gantry crash on iqex

### DIFF
--- a/01_Default_CFG/IQEX_cfg_alpha_161125/Xp_Xplorer_Vars.cfg
+++ b/01_Default_CFG/IQEX_cfg_alpha_161125/Xp_Xplorer_Vars.cfg
@@ -33,7 +33,7 @@ variable_calp_z:         10    # Z pos nozzle Probe
 variable_xrest0:        11     # X value for T0 when resting after Cancel Print or end print
 variable_xrest1:        409     # X value for T1 when resting after Cancel Print or end print
 variable_yrest1:        410     # Y value for Gantry1 when resting after Cancel Print or end print - 2xGantry
-variable_yrest2:        320    # Y value for Gantry1 when resting after Cancel Print or end print - IQEX
+variable_yrest2:        0    # Y value for Gantry1 when resting after Cancel Print or end print - IQEX
 variable_tmpout:        43200   # Time in seconds to turn off the printer after pause or M600
 variable_s_mzx:          50    # X probepoint TILT_Z Motor Z Single
 variable_s_mzy:          40    # X probepoint TILT_Z Motor Z Single


### PR DESCRIPTION
This change keeps gantry1 at the front of the printer instead of moving to the back which resulted in a crash. 