### PR TITLE
Need to run Tool macro before brush movements for t2 and t3.

### DIFF
--- a/01_Default_CFG/IQEX_cfg_alpha_161125/Xp_Macros_IQEX.cfg
+++ b/01_Default_CFG/IQEX_cfg_alpha_161125/Xp_Macros_IQEX.cfg
@@ -1724,9 +1724,10 @@ gcode:
 gcode:
     {% set svv = printer.save_variables.variables %}
     {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
-     M118 Brushing Tool3
-     G90
-     G1 Z10 F2000
+    M118 Brushing Tool3
+    G90
+    G1 Z10 F2000
+    Tool3
 
 	SET_DUAL_CARRIAGE CARRIAGE=gantry0
     SET_DUAL_CARRIAGE CARRIAGE=t0
@@ -1834,9 +1835,10 @@ gcode:
 gcode:
     {% set svv = printer.save_variables.variables %}
     {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
-     M118 Brushing Tool2
-     G90  
-     G1 Z10
+    M118 Brushing Tool2
+    G90
+    G1 Z10
+    Tool2
 
 	SET_DUAL_CARRIAGE CARRIAGE=gantry0
     SET_DUAL_CARRIAGE CARRIAGE=t1


### PR DESCRIPTION
@Dan3dp I was testing the klipper fork functionality for iqex and I started with testing the brush macros. Noticed that tool2 and tool3 aren't called during the brush so we get movement errors. This fix corrects that as well as fixes some spacing inconsistencies 