### PR TITLE
Last rodeo

### DIFF
--- a/.7_XP_modules/xptools_calibrate.py
+++ b/.7_XP_modules/xptools_calibrate.py
@@ -389,118 +389,72 @@ class ProbeEndstopWrapper:
             return toolhead.get_status(curtime).get('extruder')
 
     def _get_steppers(self):
-        """
-        Select steppers based on axis and currently active extruder.
-
-        X: per tool
-          extruder  -> stepper x
-          extruder1 -> stepper x1
-          extruder2 -> stepper x2
-          extruder3 -> stepper x3
-
-        Y: per gantry
-          extruder/extruder1 -> stepper y,  stepper y1
-          extruder2/extruder3 -> stepper y2, stepper y3
-
-        Z (and others): fallback to underlying endstop mapping.
-        """
-        def _fallback(axis_label, extr_name, all_names):
-            st_fb = self.mcu_endstop.get_steppers()
-            try:
-                chosen_fb = [s.get_name() for s in st_fb]
-            except Exception:
-                chosen_fb = [str(s) for s in st_fb]
-            self.printer.lookup_object('gcode').respond_info(
-                f"DEBUG get_steppers axis={axis_label} extr={extr_name} fallback={chosen_fb} all={all_names}"
-            )
-            return st_fb
+        def _norm(name):
+            return str(name).strip().replace(" ", "_")
 
         toolhead = self.printer.lookup_object('toolhead')
         kin = toolhead.get_kinematics()
 
-        all_names = []
+        # Build a normalized-name -> stepper-object map
+        stepper_by_name = {}
         for s in kin.get_steppers():
             try:
-                all_names.append(s.get_name())
+                nm = s.get_name()
             except Exception:
-                all_names.append(str(s))
+                nm = str(s)
+            stepper_by_name[_norm(nm)] = s
 
         extr = self._active_extruder_name()
 
         # X axis: per tool stepper
         if self.axis == 'x':
             want = {
-                'extruder':  ['stepper x'],
-                'extruder1': ['stepper x1'],
-                'extruder2': ['stepper x2'],
-                'extruder3': ['stepper x3'],
+                'extruder':  ['stepper_x'],
+                'extruder1': ['stepper_x1'],
+                'extruder2': ['stepper_x2'],
+                'extruder3': ['stepper_x3'],
             }.get(extr)
 
             if want is None:
-                return _fallback('x', extr, all_names)
+                return self.mcu_endstop.get_steppers()
 
             chosen = []
-            for s in kin.get_steppers():
-                try:
-                    nm = s.get_name()
-                except Exception:
-                    continue
-                if nm in want:
-                    chosen.append(s)
-
-            if len(chosen) != len(want):
-                raise self.printer.command_error(
-                    f"tools_calibrate: axis=x active extruder={extr} expected {want} "
-                    f"but found {[c.get_name() for c in chosen]}. Available steppers: {all_names}"
-                )
-
-            self.printer.lookup_object('gcode').respond_info(
-                f"DEBUG get_steppers axis=x extr={extr} chosen={[s.get_name() for s in chosen]} all={all_names}"
-            )
+            for w in want:
+                ws = stepper_by_name.get(_norm(w))
+                if ws is None:
+                    raise self.printer.command_error(
+                        f"tools_calibrate: axis=x active extruder={extr} expected {want} "
+                        f"but stepper '{w}' was not found"
+                    )
+                chosen.append(ws)
             return chosen
 
         # Y axis: per gantry steppers
         if self.axis == 'y':
             want = {
-                'extruder':  ['stepper y', 'stepper y1'],
-                'extruder1': ['stepper y', 'stepper y1'],
-                'extruder2': ['stepper y2', 'stepper y3'],
-                'extruder3': ['stepper y2', 'stepper y3'],
+                'extruder':  ['stepper_y', 'stepper_y1'],
+                'extruder1': ['stepper_y', 'stepper_y1'],
+                'extruder2': ['stepper_y2', 'stepper_y3'],
+                'extruder3': ['stepper_y2', 'stepper_y3'],
             }.get(extr)
 
             if want is None:
-                return _fallback('y', extr, all_names)
+                return self.mcu_endstop.get_steppers()
 
             chosen = []
-            for s in kin.get_steppers():
-                try:
-                    nm = s.get_name()
-                except Exception:
-                    continue
-                if nm in want:
-                    chosen.append(s)
-
-            if len(chosen) != len(want):
-                raise self.printer.command_error(
-                    f"tools_calibrate: axis=y active extruder={extr} expected {want} "
-                    f"but found {[c.get_name() for c in chosen]}. Available steppers: {all_names}"
-                )
-
-            self.printer.lookup_object('gcode').respond_info(
-                f"DEBUG get_steppers axis=y extr={extr} chosen={[s.get_name() for s in chosen]} all={all_names}"
-            )
+            for w in want:
+                ws = stepper_by_name.get(_norm(w))
+                if ws is None:
+                    raise self.printer.command_error(
+                        f"tools_calibrate: axis=y active extruder={extr} expected {want} "
+                        f"but stepper '{w}' was not found"
+                    )
+                chosen.append(ws)
             return chosen
 
         # Other axes (Z): default wrapper selection
-        st = self.mcu_endstop.get_steppers()
-        try:
-            chosen = [s.get_name() for s in st]
-        except Exception:
-            chosen = [str(s) for s in st]
-        self.printer.lookup_object('gcode').respond_info(
-            f"DEBUG get_steppers axis={self.axis} chosen={chosen}"
-        )
-        return st
+        return self.mcu_endstop.get_steppers()
+
 
     def _handle_mcu_identify(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()

--- a/.7_XP_modules/xptools_calibrate.py
+++ b/.7_XP_modules/xptools_calibrate.py
@@ -258,12 +258,6 @@ class PrinterProbeMultiAxis:
         except Exception:
             pre = None
 
-        self.gcode.respond_info(
-            "DEBUG probe begin dir=%s axis=%d sense=%d pre_endstop=%s"
-            % (direction_label, axis, sense, str(pre))
-        )
-
-        # If the probe is already triggered, abort early to avoid shoving harder.
         if pre:
             raise self.printer.command_error("Probe triggered prior to movement")
 
@@ -277,8 +271,6 @@ class PrinterProbeMultiAxis:
                 reason += HINT_TIMEOUT
             raise self.printer.command_error(reason)
 
-        self.gcode.respond_info("Probe made contact at %.6f,%.6f,%.6f"
-                                % (epos[0], epos[1], epos[2]))
         return epos[:3]
 
     def _calc_mean(self, positions):

--- a/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
@@ -160,12 +160,8 @@ gcode:
     {% set offsets = printer["xptools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
-        {% set y_raw    = offsets[1] %}
+        {% set y_offset = offsets[1]|round(6) %}
         {% set z_offset = (offsets[2] * -1)|round(6) %}
-
-        {% set xplorer  = printer['gcode_macro _XPLORER_VARIABLES'] %}
-        {% set y_offset = (y_raw + xplorer.y_off_dg)|round(6) %}
-
         SAVE_VARIABLE VARIABLE=x2offset VALUE={x_offset}
         SAVE_VARIABLE VARIABLE=y2offset VALUE={y_offset}
         SAVE_VARIABLE VARIABLE=z2offset VALUE={z_offset}
@@ -184,12 +180,8 @@ gcode:
     {% set offsets = printer["xptools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
-        {% set y_raw    = offsets[1] %}
+        {% set y_offset = offsets[1]|round(6) %}
         {% set z_offset = (offsets[2] * -1)|round(6) %}
-
-        {% set xplorer  = printer['gcode_macro _XPLORER_VARIABLES'] %}
-        {% set y_offset = (y_raw + xplorer.y_off_dg)|round(6) %}
-
         SAVE_VARIABLE VARIABLE=x3offset VALUE={x_offset}
         SAVE_VARIABLE VARIABLE=y3offset VALUE={y_offset}
         SAVE_VARIABLE VARIABLE=z3offset VALUE={z_offset}
@@ -197,7 +189,6 @@ gcode:
     {% else %}
         M118 Error: No offsets to save for Tool3.
     {% endif %}
-
 
 ###################################
 # Calibrate probe offset

--- a/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
@@ -157,7 +157,7 @@ gcode:
 [gcode_macro _save_offsets_t2]
 description: Save Tool2 offsets into variables.cfg
 gcode:
-    {% set offsets = printer["tools_calibrate"].last_result %}
+    {% set offsets = printer["xptools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
         {% set y_raw    = offsets[1] %}
@@ -181,7 +181,7 @@ gcode:
 [gcode_macro _save_offsets_t3]
 description: Save Tool3 offsets into variables.cfg
 gcode:
-    {% set offsets = printer["tools_calibrate"].last_result %}
+    {% set offsets = printer["xptools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
         {% set y_raw    = offsets[1] %}

--- a/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
@@ -157,11 +157,15 @@ gcode:
 [gcode_macro _save_offsets_t2]
 description: Save Tool2 offsets into variables.cfg
 gcode:
-    {% set offsets = printer["xptools_calibrate"].last_result %}
+    {% set offsets = printer["tools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
-        {% set y_offset = offsets[1]|round(6) %}
+        {% set y_raw    = offsets[1] %}
         {% set z_offset = (offsets[2] * -1)|round(6) %}
+
+        {% set xplorer  = printer['gcode_macro _XPLORER_VARIABLES'] %}
+        {% set y_offset = (y_raw + xplorer.y_off_dg)|round(6) %}
+
         SAVE_VARIABLE VARIABLE=x2offset VALUE={x_offset}
         SAVE_VARIABLE VARIABLE=y2offset VALUE={y_offset}
         SAVE_VARIABLE VARIABLE=z2offset VALUE={z_offset}
@@ -177,11 +181,15 @@ gcode:
 [gcode_macro _save_offsets_t3]
 description: Save Tool3 offsets into variables.cfg
 gcode:
-    {% set offsets = printer["xptools_calibrate"].last_result %}
+    {% set offsets = printer["tools_calibrate"].last_result %}
     {% if offsets %}
         {% set x_offset = offsets[0]|round(6) %}
-        {% set y_offset = offsets[1]|round(6) %}
+        {% set y_raw    = offsets[1] %}
         {% set z_offset = (offsets[2] * -1)|round(6) %}
+
+        {% set xplorer  = printer['gcode_macro _XPLORER_VARIABLES'] %}
+        {% set y_offset = (y_raw + xplorer.y_off_dg)|round(6) %}
+
         SAVE_VARIABLE VARIABLE=x3offset VALUE={x_offset}
         SAVE_VARIABLE VARIABLE=y3offset VALUE={y_offset}
         SAVE_VARIABLE VARIABLE=z3offset VALUE={z_offset}
@@ -189,6 +197,7 @@ gcode:
     {% else %}
         M118 Error: No offsets to save for Tool3.
     {% endif %}
+
 
 ###################################
 # Calibrate probe offset


### PR DESCRIPTION
Alright, features for this PR are as follows:

* removing debug logging from tool changer library. It's chatty! 
* unify the tool changer calibration library to work for both single gantry idex and dual gantry iqex. Needs additional logic to support dual gantry idex.
* I found a bug in my logic for calculating the Y offset for tool 2 and tool 3 with regards to it's starting offset of ~57.5. This was being rolled up in the offset calcuation that happens when running the `tooln` macros. Basically, it was componding the offset. This PR fixes that as well. 

Image shows that debug logging is gone and that the offsets for tool 2 and 3 are now more accurate to what we'd expect :sunglasses: 

<img width="1490" height="1256" alt="2025-12-16-235642_grim" src="https://github.com/user-attachments/assets/83881f80-f7b9-4f0e-aa83-f9ba62b9f2bc" />

