### PR TITLE
No homing iqex tool offset macro updates

### DIFF
--- a/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
@@ -42,6 +42,8 @@ gcode:
     M118 === Calibrating ALL tool offsets (T0 baseline) ===
     M118 The nozzles MUST BE PERFECTLY CLEAN !!!
 
+    CHECK_HOME
+
     ZERO_TOOL_OFFSETS
 
     # Heat T0 and T1 to probe temp

--- a/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Calibrate_offsets_IQEX.cfg
@@ -42,8 +42,6 @@ gcode:
     M118 === Calibrating ALL tool offsets (T0 baseline) ===
     M118 The nozzles MUST BE PERFECTLY CLEAN !!!
 
-    CHECK_HOME
-
     ZERO_TOOL_OFFSETS
 
     # Heat T0 and T1 to probe temp
@@ -86,7 +84,6 @@ gcode:
     # move gantry0 to max
     # move tool1 left ~100mm
     G90
-    ACTIVATE_EXTRUDER EXTRUDER=extruder1
     SET_DUAL_CARRIAGE CARRIAGE=gantry0
     SET_DUAL_CARRIAGE CARRIAGE=t1
     G1 X340 Y450 F9000
@@ -99,14 +96,20 @@ gcode:
     TOOL_CALIBRATE_TOOL_OFFSET
     _save_offsets_t2
     M104 T2 S0
-    G28 Y
-    G28 X
+    # Move Gantry1 Y axis away from danger zone
+    G1 Y200 F9000
+    # Move T2 to home x position
+    G1 X1 F9000
+    # Move T1 to home x position
+    SET_DUAL_CARRIAGE CARRIAGE=gantry0
+    SET_DUAL_CARRIAGE CARRIAGE=t1
+    G1 X419 F1000
+
 
     # --- Tool3 on gantry1/t3 ---
     # move gantry0 to max
     # move tool0 right ~100mm
     G90
-    ACTIVATE_EXTRUDER EXTRUDER=extruder1
     SET_DUAL_CARRIAGE CARRIAGE=gantry0
     SET_DUAL_CARRIAGE CARRIAGE=t0
     G1 X80 Y450 F9000
@@ -120,8 +123,14 @@ gcode:
     TOOL_CALIBRATE_TOOL_OFFSET
     _save_offsets_t3
     M104 T3 S0
-    G28 Y
-    G28 X
+    # Move Gantry1 Y axis to home position
+    G1 Y58 F9000
+    # Move T3 to home x position
+    G1 X419 F9000
+    # Move T1 to home x position
+    SET_DUAL_CARRIAGE CARRIAGE=gantry0
+    SET_DUAL_CARRIAGE CARRIAGE=t0
+    G1 X1 F9000
 
     M118 === Tool offset calibration complete ===
 


### PR DESCRIPTION
So the end stops are great for this level of fine motion control. So what ends up happening is that during tool 2 and 3 calibration, there are a few rounds of homing. Each time this homes, this has a slightly different value that ultimately affects calibration for gantry1. 

This PR simply changes from a homing movement for gantry and tools to instead just driving them with gcode to standard start positions. 

Ideally, this would be incorporated into the START_PRINT macro...but that will require a bit of engineering. There is a bit of logic that is happening in the slicer that the START_MACRO doesn't manage. 

For implementation on my system, in the slicer, I have the following:
```
PRINT_START BED=[first_layer_bed_temperature] EXTRUDER={first_layer_temperature[0]} EXTRUDER1={first_layer_temperature[1]} EXTRUDER2={first_layer_temperature[2]} EXTRUDER3={first_layer_temperature[3]} CHAMBER=[chamber_temperature] INITIAL_TOOL={initial_extruder} SKEW=SKEW1
```

My print start macro is this:
```
[gcode_macro PRINT_START]
description: Centralized start sequence with optional multi-extruder + chamber (IDEX/IQEX aware)
# Usage:
#  PRINT_START BED=60 EXTRUDER=220 [EXTRUDER1=210] [EXTRUDER2=0] [EXTRUDER3=0] [CHAMBER=40] [TOOL=0|1|2|3] [DEFER_MODE=0|1]
# Optional: SAFE_X=210 SAFE_Y=200 SAFE_Z=10  (override the default unpark location)
gcode:
    {% set bed      = params.BED|default(0)|float %}
    {% set e0       = params.EXTRUDER|default(0)|float %}
    {% set e1       = params.EXTRUDER1|default(0)|float %}
    {% set e2       = params.EXTRUDER2|default(0)|float %}
    {% set e3       = params.EXTRUDER3|default(0)|float %}
    {% set chamber  = params.CHAMBER|default(0)|float %}
    {% set tool     = params.TOOL|default(0)|int %}
    {% set sx       = params.SAFE_X|default(210)|float %}
    {% set sy       = params.SAFE_Y|default(200)|float %}
    {% set sz       = params.SAFE_Z|default(10)|float %}
    {% set unpark   = params.UNPARK|default(0)|int %}

    # --- Setup ---
    SET_GCODE_OFFSET Z=0                                   # Reset Z offset
    G28                                                    # Home all axes
    G90                                                    # Absolute positioning

    # Defer applying print mode until after tool preheats (heat-first policy)

    # --- Step 1: Bed heat (optional) ---
    {% if bed > 0 %}
        LED_BED_HEATING_ON
        SET_DISPLAY_TEXT MSG='Heating Bed: { bed }°C'
        M140 S{bed}
        M190 S{bed}
        LED_BED_HEATING_OFF
        LED_ALL_IDLE
    {% endif %}

    # --- Step 2: Any pre-cal/align routine you use ---
    TANGO_TIME EXTRUDER={e0} EXTRUDER1={e1} EXTRUDER2={e2} EXTRUDER3={e3}
    {% if pmode == 0 %}
        AUTO_CALIBRATE_tool_offsets
    {% endif %}

    # --- Step 3: Tool preheats without changing active tool ---
    SET_DISPLAY_TEXT MSG='Heating Gantry 0: t0: { e0 }°C & t1: { e1 }°C'
    {% if e0 > 0 %} SET_LED_EFFECT EFFECT=tool0_heating REPLACE=1 {% endif %}
    {% if e1 > 0 %} SET_LED_EFFECT EFFECT=tool1_heating REPLACE=1 {% endif %}
    {% if e0 > 0 %} SET_HEATER_TEMPERATURE HEATER=extruder  TARGET={e0} {% endif %}
    {% if e1 > 0 %} SET_HEATER_TEMPERATURE HEATER=extruder1 TARGET={e1} {% endif %}
    {% if e0 > 0 %} TEMPERATURE_WAIT   SENSOR=extruder  MINIMUM={e0}   MAXIMUM={e0+1} {% endif %}
    {% if e1 > 0 %} TEMPERATURE_WAIT   SENSOR=extruder1 MINIMUM={e1}   MAXIMUM={e1+1} {% endif %}

    # Return Gantry 0 tools to idle effect after heating
    {% if e0 > 0 %} SET_LED_EFFECT EFFECT=tool0_idle REPLACE=1 {% endif %}
    {% if e1 > 0 %} SET_LED_EFFECT EFFECT=tool1_idle REPLACE=1 {% endif %}

    SET_DISPLAY_TEXT MSG='Heating Gantry 1: t2: { e2 }°C & t3: { e3 }°C'
    {% if e2 > 0 %} SET_LED_EFFECT EFFECT=tool2_heating REPLACE=1 {% endif %}
    {% if e3 > 0 %} SET_LED_EFFECT EFFECT=tool3_heating REPLACE=1 {% endif %}
    {% if e2 > 0 %} SET_HEATER_TEMPERATURE HEATER=extruder2 TARGET={e2} {% endif %}
    {% if e3 > 0 %} SET_HEATER_TEMPERATURE HEATER=extruder3 TARGET={e3} {% endif %}
    {% if e2 > 0 %} TEMPERATURE_WAIT   SENSOR=extruder2 MINIMUM={e2}   MAXIMUM={e2+1} {% endif %}
    {% if e3 > 0 %} TEMPERATURE_WAIT   SENSOR=extruder3 MINIMUM={e3}   MAXIMUM={e3+1} {% endif %}

    # Return Gantry 1 tools to idle effect after heating
    {% if e2 > 0 %} SET_LED_EFFECT EFFECT=tool2_idle REPLACE=1 {% endif %}
    {% if e3 > 0 %} SET_LED_EFFECT EFFECT=tool3_idle REPLACE=1 {% endif %}

    # --- Optional chamber control ---
    {% if chamber > 0 and printer["gcode_macro SET_TEMPERATURE_FAN_TARGET"] is defined %}
        SET_TEMPERATURE_FAN_TARGET TEMPERATURE_FAN=Electronics_fan TARGET={chamber}
    {% endif %}

    # --- Factory niceties (guarded) ---
    M400
    {% if printer.skew_correction is defined %}
        {% set skew_name = 'SKEW0' %}
        SKEW_PROFILE LOAD={skew_name}
    {% endif %}
    {% if printer["gcode_macro save_last_file"] is defined %} save_last_file {% endif %}
    {% if printer["gcode_macro G31"] is defined %} G31 {% endif %}
    {% if printer["gcode_macro SAVE_VARIABLE"] is defined %}
        SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
        SAVE_VARIABLE VARIABLE=xy_resume VALUE=1
        SAVE_VARIABLE VARIABLE=ttover_resume VALUE=0
    {% endif %}
    {% if printer["gcode_macro SET_VELOCITY_LIMIT"] is defined %}
        SET_VELOCITY_LIMIT VELOCITY=350 ACCEL=15000
    {% else %}
        SET_VELOCITY_LIMIT VELOCITY=350 ACCEL=15000
    {% endif %}
    G92 E0

    # Apply printing mode
    START_PRINTING_MODE

    # --- LED: final “we are now printing” state based on pmode/tool ---
    {% set svv = printer.save_variables.variables %}
    {% set pmode = svv.pmode|default(0)|int %}

    {% if pmode == 0 %}
        # PRIMARY single-tool mode
        # Prefer explicit TOOL= param if provided; otherwise infer from current extruder
        {% if params.TOOL is defined %}
            LED_SET_ACTIVE_TOOL TOOL={tool}
        {% else %}
            LED_ACTIVE_TOOL_FROM_EXTRUDER
        {% endif %}

    {% elif pmode in [1, 2] %}
        # T1 COPY / MIRROR T0
        LED_SET_ACTIVE_TOOLS T0=1 T1=1 T2=0 T3=0

    {% elif pmode in [3, 4] %}
        # T1,T2,T3 COPY T0  OR  T2,T3 MIRROR T0,T1  (all four printing)
        LED_SET_ACTIVE_TOOLS T0=1 T1=1 T2=1 T3=1

    {% else %}
        # Unknown / future mode – fail safe to idle
        LED_ALL_IDLE
    {% endif %}

    SET_DISPLAY_TEXT MSG='Now Printing'
```

You can see that after I run tango time which is my bed leveling routine for z tilt and probed z offset, I run the tool calibration only if mode is primary. After that, I never make a homing call. 

I don't know if this PR will make a huge impact as is since the current default macro for factory printers makes multiple homing calls after bed leveling. I think the issue for the gap defect is squarely on homing calls after calibration has been done which cannot happen due to the imprecise nature of these endstops. Perhaps we can treat this PR like a branch and flush out a new print start macro as well as new profiles for orca? Not sure. But this PR has depends on other things that are more integrated than just this macro. 