### PR TITLE
backport: add IQEX multicolor copy/mirror modes (pmode 5/6) and resonance calibration

### DIFF
--- a/.8_Scripts/resonances_X_mccpt0.sh
+++ b/.8_Scripts/resonances_X_mccpt0.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_x_xmccpt0_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_x_*.csv" -o -name "calibration_data_x_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_x_*.csv or calibration_data_x_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_xmccpt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_xmccpt0.*/shaper_type_xmccpt0 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_xmccpt0 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_xmccpt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_xmccpt0.*/shaper_freq_xmccpt0 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_xmccpt0 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_X_mccpt1.sh
+++ b/.8_Scripts/resonances_X_mccpt1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_x_xmccpt1_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_x_*.csv" -o -name "calibration_data_x_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_x_*.csv or calibration_data_x_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_xmccpt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_xmccpt1.*/shaper_type_xmccpt1 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_xmccpt1 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_xmccpt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_xmccpt1.*/shaper_freq_xmccpt1 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_xmccpt1 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_X_mcmrt0.sh
+++ b/.8_Scripts/resonances_X_mcmrt0.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_x_xmcmrt0_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_x_*.csv" -o -name "calibration_data_x_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_x_*.csv or calibration_data_x_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_xmcmrt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_xmcmrt0.*/shaper_type_xmcmrt0 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_xmcmrt0 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_xmcmrt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_xmcmrt0.*/shaper_freq_xmcmrt0 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_xmcmrt0 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_X_mcmrt1.sh
+++ b/.8_Scripts/resonances_X_mcmrt1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_x_xmcmrt1_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_x_*.csv" -o -name "calibration_data_x_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_x_*.csv or calibration_data_x_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_xmcmrt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_xmcmrt1.*/shaper_type_xmcmrt1 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_xmcmrt1 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_xmcmrt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_xmcmrt1.*/shaper_freq_xmcmrt1 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_xmcmrt1 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_Y_mccpt0.sh
+++ b/.8_Scripts/resonances_Y_mccpt0.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_y_ymccpt0_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_y_*.csv" -o -name "calibration_data_y_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_y_*.csv or calibration_data_y_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_ymccpt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_ymccpt0.*/shaper_type_ymccpt0 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_ymccpt0 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_ymccpt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_ymccpt0.*/shaper_freq_ymccpt0 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_ymccpt0 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_Y_mccpt1.sh
+++ b/.8_Scripts/resonances_Y_mccpt1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_y_ymccpt1_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_y_*.csv" -o -name "calibration_data_y_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_y_*.csv or calibration_data_y_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_ymccpt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_ymccpt1.*/shaper_type_ymccpt1 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_ymccpt1 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_ymccpt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_ymccpt1.*/shaper_freq_ymccpt1 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_ymccpt1 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_Y_mcmrt0.sh
+++ b/.8_Scripts/resonances_Y_mcmrt0.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_y_ymcmrt0_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_y_*.csv" -o -name "calibration_data_y_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_y_*.csv or calibration_data_y_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_ymcmrt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_ymcmrt0.*/shaper_type_ymcmrt0 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_ymcmrt0 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_ymcmrt0" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_ymcmrt0.*/shaper_freq_ymcmrt0 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_ymcmrt0 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/.8_Scripts/resonances_Y_mcmrt1.sh
+++ b/.8_Scripts/resonances_Y_mcmrt1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Get the current time and date
+time_str=$(date +"%H%M")
+date_str=$(date +"%d%m%Y")
+
+# Construct the output filename
+output_filename="/home/biqu/printer_data/config/03_Resonances_Measurments/shaper_calibrate_y_ymcmrt1_${time_str}_${date_str}.png"
+
+# Find the most recently created file matching the patterns
+latest_file=$(find /tmp -maxdepth 1 -type f \( -name "resonances_y_*.csv" -o -name "calibration_data_y_*.csv" \) -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+
+# Check if a valid file was found
+if [ -z "$latest_file" ]; then
+  echo "Error: No matching file found for resonances_y_*.csv or calibration_data_y_*.csv"
+  exit 1
+fi
+
+# Debugging: print the selected file
+echo "Using file: $latest_file"
+
+# Run the Python script and capture its output
+shaper_output=$(~/klipper/scripts/calibrate_shaper.py "$latest_file" -o "$output_filename")
+
+# Print the output filename
+echo "Output file: $output_filename"
+
+# Extract the recommended shaper type and frequency
+recommended_shaper=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $4}')
+recommended_freq=$(echo "$shaper_output" | grep "Recommended shaper" | awk '{print $6}')
+
+# Check if extraction was successful
+if [ -z "$recommended_shaper" ] || [ -z "$recommended_freq" ]; then
+  echo "Error: Could not extract recommended shaper or frequency"
+  exit 1
+fi
+
+# Define the configuration file path
+config_file="/home/biqu/printer_data/config/variables.cfg"
+
+# Backup the configuration file as a hidden file
+cp "$config_file" "/home/biqu/printer_data/config/.variables.cfg.bak"
+
+# Update or add the shaper settings
+if grep -q "^shaper_type_ymcmrt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_type_ymcmrt1.*/shaper_type_ymcmrt1 = '$recommended_shaper'/" "$config_file"
+else
+  # Add new entry with a newline
+  echo -e "\nshaper_type_ymcmrt1 = '$recommended_shaper'" >> "$config_file"
+fi
+
+if grep -q "^shaper_freq_ymcmrt1" "$config_file"; then
+  # Update existing entries
+  sed -i "s/^shaper_freq_ymcmrt1.*/shaper_freq_ymcmrt1 = $recommended_freq/" "$config_file"
+else
+  # Add new entry with a newline
+  echo "shaper_freq_ymcmrt1 = $recommended_freq" >> "$config_file"
+fi
+
+# Ensure proper formatting by adding a newline after the last variable if needed
+sed -i -e '$a\' "$config_file"
+
+echo "Recommended shaper settings updated in $config_file"
+echo "Backup saved as /home/biqu/printer_data/config/.variables.cfg.bak"

--- a/01_Default_CFG/Xp_Macros_Base.cfg
+++ b/01_Default_CFG/Xp_Macros_Base.cfg
@@ -3,6 +3,16 @@
 # Z_TILT_ADJUST
 ##################################
 
+[gcode_macro _RETRACT_IF_PRINTING]
+gcode:
+    {% if printer.print_stats.state in ["printing", "paused"] and printer[printer.toolhead.extruder].can_extrude %}
+        {% set svv = printer.save_variables.variables %}
+        SAVE_GCODE_STATE NAME=_retract_tc
+        M83
+        G1 E-{svv.tc_retract} F2400
+        RESTORE_GCODE_STATE NAME=_retract_tc
+    {% endif %}
+
 [gcode_macro Z_TILT_ADJUST]
 rename_existing: BASE_Z_TILT_ADJUST
 gcode:

--- a/01_Default_CFG/Xp_V1.1_Macros_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Macros_IQEX.cfg
@@ -360,18 +360,18 @@ gcode:
 gcode:
     M118 Activating COPY mode T0 / T1
     {% set svv = printer.save_variables.variables %}
-    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %} 
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
     SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
     SET_DUAL_CARRIAGE CARRIAGE=gantry0 MODE=PRIMARY
-    G1 X0 F{xplorer.sp_pmode}   
+    G1 X0 F{xplorer.sp_pmode}
     ACTIVATE_EXTRUDER EXTRUDER=extruder
     SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=PRIMARY
     G1 X{xplorer.x_cop_idex}
     SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
-    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=COPY    
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=COPY
     SYNC_EXTRUDER_MOTION EXTRUDER=extruder1 MOTION_QUEUE=extruder
     SAVE_VARIABLE VARIABLE=pmode VALUE=1
-    
+
     {% if svv.shaper_type_xidexcp is defined and
           svv.shaper_freq_xidexcp is defined and
           svv.shaper_type_yidexcp is defined and
@@ -387,18 +387,18 @@ gcode:
 gcode:
     M118 Activating MIRROR mode T0 / T1
     {% set svv = printer.save_variables.variables %}
-    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %} 
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
     SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
     SET_DUAL_CARRIAGE CARRIAGE=gantry0 MODE=PRIMARY
-    G1 X0 F{xplorer.sp_pmode}   
+    G1 X0 F{xplorer.sp_pmode}
     ACTIVATE_EXTRUDER EXTRUDER=extruder
     SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=PRIMARY
     G1 X{xplorer.x_mir_idex}
     SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
-    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=MIRROR    
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=MIRROR
     SYNC_EXTRUDER_MOTION EXTRUDER=extruder1 MOTION_QUEUE=extruder
     SAVE_VARIABLE VARIABLE=pmode VALUE=2
-    
+
     {% if svv.shaper_type_xidexmr is defined and
           svv.shaper_freq_xidexmr is defined and
           svv.shaper_type_yidexmr is defined and
@@ -412,6 +412,266 @@ gcode:
 ####################################################################
 # Copy Mode IQEX T0/T1 T2 T3
 ####################################################################
+
+
+####################################################################
+# MULTICOLOR COPY Mode IQEX T0/T1
+####################################################################
+
+[gcode_macro ACTIVATE_MULTICOLOR_COPY_MODE01]
+gcode:
+    M118 Activating MULTICOLOR COPY mode T0 / T1
+    {% set svv = printer.save_variables.variables %}
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
+    SET_DUAL_CARRIAGE CARRIAGE=gantry0 MODE=PRIMARY
+    G1 X0 F{xplorer.sp_pmode}
+    G28 Y
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=PRIMARY
+    G1 X{xplorer.x_cop_idex}
+    SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=COPY
+    SYNC_EXTRUDER_MOTION EXTRUDER=extruder1 MOTION_QUEUE=extruder
+    SAVE_VARIABLE VARIABLE=pmode VALUE=5
+
+    {% if svv.shaper_type_xmccpt0 is defined and
+          svv.shaper_freq_xmccpt0 is defined and
+          svv.shaper_type_ymccpt0 is defined and
+          svv.shaper_freq_ymccpt0 is defined %}
+        SET_INPUT_SHAPER SHAPER_TYPE_X={svv.shaper_type_xmccpt0} SHAPER_FREQ_X={svv.shaper_freq_xmccpt0} SHAPER_TYPE_Y={svv.shaper_type_ymccpt0} SHAPER_FREQ_Y={svv.shaper_freq_ymccpt0}
+    {% endif %}
+
+
+####################################################################
+# MULTICOLOR MIRROR Mode IQEX T0/T1
+####################################################################
+
+[gcode_macro ACTIVATE_MULTICOLOR_MIRROR_MODE01]
+gcode:
+    M118 Activating MULTICOLOR MIRROR mode T0 / T1
+    {% set svv = printer.save_variables.variables %}
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
+    SET_DUAL_CARRIAGE CARRIAGE=gantry0 MODE=PRIMARY
+    G1 X0 F{xplorer.sp_pmode}
+    G28 Y
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=PRIMARY
+    G1 X{xplorer.x_mir_idex}
+    SET_DUAL_CARRIAGE CARRIAGE=t0 MODE=PRIMARY
+    SET_DUAL_CARRIAGE CARRIAGE=t1 MODE=MIRROR
+    SYNC_EXTRUDER_MOTION EXTRUDER=extruder1 MOTION_QUEUE=extruder
+    SAVE_VARIABLE VARIABLE=pmode VALUE=6
+
+    {% if svv.shaper_type_xmcmrt0 is defined and
+          svv.shaper_freq_xmcmrt0 is defined and
+          svv.shaper_type_ymcmrt0 is defined and
+          svv.shaper_freq_ymcmrt0 is defined %}
+        SET_INPUT_SHAPER SHAPER_TYPE_X={svv.shaper_type_xmcmrt0} SHAPER_FREQ_X={svv.shaper_freq_xmcmrt0} SHAPER_TYPE_Y={svv.shaper_type_ymcmrt0} SHAPER_FREQ_Y={svv.shaper_freq_ymcmrt0}
+    {% endif %}
+
+
+####################################################################
+# Multicolor Tool0
+####################################################################
+
+[gcode_macro _MC_TOOL0]
+gcode:
+    # Save state and park inactive extruders for tool change
+    SAVE_GCODE_STATE NAME=_mc_tool0_park
+    _MC_CALIBRATE_PARK_INACTIVES
+
+    # Retract if printing (active extruder stays, others park)
+    _RETRACT_IF_PRINTING
+
+    # Set dual carriage to T0
+    SET_DUAL_CARRIAGE CARRIAGE=t0
+    {% set svv = printer.save_variables.variables %}
+    SET_INPUT_SHAPER SHAPER_TYPE_X={svv.shaper_type_xt0} SHAPER_FREQ_X={svv.shaper_freq_xt0} SHAPER_TYPE_Y={svv.shaper_type_yt0} SHAPER_FREQ_Y={svv.shaper_freq_yt0}
+
+    RESTORE_GCODE_STATE NAME=_mc_tool0_park
+
+
+####################################################################
+# Multicolor Tool1
+####################################################################
+
+[gcode_macro _MC_TOOL1]
+gcode:
+    # Save state and park inactive extruders for tool change
+    SAVE_GCODE_STATE NAME=_mc_tool1_park
+    _MC_CALIBRATE_PARK_INACTIVES
+
+    # Retract if printing (active extruder stays, others park)
+    _RETRACT_IF_PRINTING
+
+    # Set dual carriage to T1
+    SET_DUAL_CARRIAGE CARRIAGE=t1
+    {% set svv = printer.save_variables.variables %}
+    SET_INPUT_SHAPER SHAPER_TYPE_X={svv.shaper_type_xt1} SHAPER_FREQ_X={svv.shaper_freq_xt1} SHAPER_TYPE_Y={svv.shaper_type_yt1} SHAPER_FREQ_Y={svv.shaper_freq_yt1}
+
+    RESTORE_GCODE_STATE NAME=_mc_tool1_park
+
+
+####################################################################
+# Multicolor Calibrate Park Inactives
+####################################################################
+
+[gcode_macro _MC_CALIBRATE_PARK_INACTIVES]
+gcode:
+    # Park any inactive extruders while keeping the active one for retraction
+    {% set active = printer.toolhead.extruder %}
+    {% if active != "extruder" %}
+        ACTIVATE_EXTRUDER EXTRUDER=extruder
+        {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+        G90
+        G1 X{xplorer.xrest0} F{xplorer.sp_tch}
+        {% if active != "extruder1" %}
+            SET_DUAL_CARRIAGE CARRIAGE=t1
+            G1 X{xplorer.xrest1} F{xplorer.sp_tch}
+        {% endif %}
+    {% endif %}
+
+
+####################################################################
+# Multicolor Resonance Calibration - X Copy Phase0
+####################################################################
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_COPY_PHASE0_X]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_x_mccpt0
+    M118 Resonance Calib: Multicolor Copy Phase0 X-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmccpt0} Y{xplorer.res_ymccpt0} F{xplorer.sp_tch}
+    M118 X: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mccpt0 {freq_start} {freq_end} {hz_per_sec}"
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_COPY_PHASE0_Y]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_y_mccpt0
+    M118 Resonance Calib: Multicolor Copy Phase0 Y-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmccpt0} Y{xplorer.res_ymccpt0} F{xplorer.sp_tch}
+    M118 Y: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mccpt0 {freq_start} {freq_end} {hz_per_sec}"
+
+
+####################################################################
+# Multicolor Resonance Calibration - X Copy Phase1
+####################################################################
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_COPY_PHASE1_X]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_x_mccpt1
+    M118 Resonance Calib: Multicolor Copy Phase1 X-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmccpt1} Y{xplorer.res_ymccpt1} F{xplorer.sp_tch}
+    M118 X: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mccpt1 {freq_start} {freq_end} {hz_per_sec}"
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_COPY_PHASE1_Y]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_y_mccpt1
+    M118 Resonance Calib: Multicolor Copy Phase1 Y-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmccpt1} Y{xplorer.res_ymccpt1} F{xplorer.sp_tch}
+    M118 Y: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mccpt1 {freq_start} {freq_end} {hz_per_sec}"
+
+
+####################################################################
+# Multicolor Resonance Calibration - X Mirror Phase0
+####################################################################
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_MIRROR_PHASE0_X]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_x_mcmrt0
+    M118 Resonance Calib: Multicolor Mirror Phase0 X-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmcmrt0} Y{xplorer.res_ymcmrt0} F{xplorer.sp_tch}
+    M118 X: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mcmrt0 {freq_start} {freq_end} {hz_per_sec}"
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_MIRROR_PHASE0_Y]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_y_mcmrt0
+    M118 Resonance Calib: Multicolor Mirror Phase0 Y-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmcmrt0} Y{xplorer.res_ymcmrt0} F{xplorer.sp_tch}
+    M118 Y: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mcmrt0 {freq_start} {freq_end} {hz_per_sec}"
+
+
+####################################################################
+# Multicolor Resonance Calibration - X Mirror Phase1
+####################################################################
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_MIRROR_PHASE1_X]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_x_mcmrt1
+    M118 Resonance Calib: Multicolor Mirror Phase1 X-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmcmrt1} Y{xplorer.res_ymcmrt1} F{xplorer.sp_tch}
+    M118 X: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mcmrt1 {freq_start} {freq_end} {hz_per_sec}"
+
+[gcode_macro RESONANCE_CALIBRATION_MULTICOLOR_MIRROR_PHASE1_Y]
+gcode:
+    RUN_SHELL_COMMAND CMD=resonaces_y_mcmrt1
+    M118 Resonance Calib: Multicolor Mirror Phase1 Y-axis
+    {% set xplorer = printer['gcode_macro _XPLORER_VARIABLES'] %}
+    {% set freq_start = params.FREQ_START|default(5)|float %}
+    {% set freq_end = params.FREQ_END|default(133)|float %}
+    {% set hz_per_sec = params.HZ_PER_SEC|default(3)|float %}
+
+    G90
+    G1 X{xplorer.res_xmcmrt1} Y{xplorer.res_ymcmrt1} F{xplorer.sp_tch}
+    M118 Y: {freq_start}-{freq_end}Hz @ {hz_per_sec}Hz/s
+    RESPOND TYPE=command MSG="start_gcode @{freq_start} @{freq_end} {hz_per_sec} 2 10 0"
+    RESPOND TYPE=command MSG="run_resonance_test mcmrt1 {freq_start} {freq_end} {hz_per_sec}"
 
 [gcode_macro ACTIVATE_COPY_MODE0123]
 gcode:
@@ -628,6 +888,12 @@ gcode:
     {%if svv.pmode == 4%}
      ACTIVATE_MIRROR_MODE0123
    {%endif%}
+   {%if svv.pmode == 5%}
+     ACTIVATE_MULTICOLOR_COPY_MODE01
+   {%endif%}
+   {%if svv.pmode == 6%}
+     ACTIVATE_MULTICOLOR_MIRROR_MODE01
+   {%endif%}
    
 ####################################################################
 # SET print mode
@@ -723,6 +989,14 @@ gcode:
             SAVE_VARIABLE VARIABLE=pmode VALUE=4
             M118 Print Mode:  T2, T3 MIRROR T0, T1
         {% endif %}
+
+    {% elif mode == "MULTICOLOR_COPY01" %}
+        SAVE_VARIABLE VARIABLE=pmode VALUE=5
+        M118 Print Mode: MULTICOLOR COPY T0/T1
+
+    {% elif mode == "MULTICOLOR_MIRROR01" %}
+        SAVE_VARIABLE VARIABLE=pmode VALUE=6
+        M118 Print Mode: MULTICOLOR MIRROR T0/T1
     {% endif %}
 
 ####################################################################
@@ -2034,6 +2308,7 @@ gcode:
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=e3temp VALUE={printer['extruder3'].target}
 
         SAVE_GCODE_STATE NAME=PAUSE
+        SAVE_DUAL_CARRIAGE_STATE NAME=PAUSE_DC
         BASE_PAUSE
 
         {% if (printer.gcode_move.position.z + z) < printer.toolhead.axis_maximum.z %}
@@ -2119,7 +2394,9 @@ gcode:
             G1 Z{zhop * -1} F900
         {% endif %}
 
-        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=60
+        # Restore dual carriage XY from pause park point (avoids double-move)
+        RESTORE_DUAL_CARRIAGE_STATE NAME=PAUSE_DC MOVE=0
+        RESTORE_GCODE_STATE NAME=PAUSE MOVE=0
         BASE_RESUME
     {% endif %}
 
@@ -2334,7 +2611,15 @@ gcode:
      G28
      RESONANCE_CALIBRATION_IQEX_Copy
      RESONANCE_CALIBRATION_IQEX_Mirror
-     M118 Resonace tests for IQEX printing modes are complete.  
+     RESONANCE_CALIBRATION_MULTICOLOR_COPY01_PHASE0_X
+     RESONANCE_CALIBRATION_MULTICOLOR_COPY01_PHASE0_Y
+     RESONANCE_CALIBRATION_MULTICOLOR_COPY01_PHASE1_X
+     RESONANCE_CALIBRATION_MULTICOLOR_COPY01_PHASE1_Y
+     RESONANCE_CALIBRATION_MULTICOLOR_MIRROR01_PHASE0_X
+     RESONANCE_CALIBRATION_MULTICOLOR_MIRROR01_PHASE0_Y
+     RESONANCE_CALIBRATION_MULTICOLOR_MIRROR01_PHASE1_X
+     RESONANCE_CALIBRATION_MULTICOLOR_MIRROR01_PHASE1_Y
+     M118 Resonance tests for IQEX and multicolor printing modes are complete.  
 
 #########################################
 # Printer Auto Calibrate IQEX

--- a/01_Default_CFG/Xp_V1.1_Shell_Commands_IQEX.cfg
+++ b/01_Default_CFG/Xp_V1.1_Shell_Commands_IQEX.cfg
@@ -66,6 +66,71 @@ command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_Y_ide
 timeout: 80
 
 #######################################################
+
+#######################################################
+# Measure Resonances on X-Axis Multicolor Copy Phase0
+#######################################################
+
+[gcode_shell_command resonaces_x_mccpt0]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_X_mccpt0.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on Y-Axis Multicolor Copy Phase0
+#######################################################
+
+[gcode_shell_command resonaces_y_mccpt0]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_Y_mccpt0.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on X-Axis Multicolor Copy Phase1
+#######################################################
+
+[gcode_shell_command resonaces_x_mccpt1]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_X_mccpt1.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on Y-Axis Multicolor Copy Phase1
+#######################################################
+
+[gcode_shell_command resonaces_y_mccpt1]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_Y_mccpt1.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on X-Axis Multicolor Mirror Phase0
+#######################################################
+
+[gcode_shell_command resonaces_x_mcmrt0]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_X_mcmrt0.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on Y-Axis Multicolor Mirror Phase0
+#######################################################
+
+[gcode_shell_command resonaces_y_mcmrt0]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_Y_mcmrt0.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on X-Axis Multicolor Mirror Phase1
+#######################################################
+
+[gcode_shell_command resonaces_x_mcmrt1]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_X_mcmrt1.sh
+timeout: 80
+
+#######################################################
+# Measure Resonances on Y-Axis Multicolor Mirror Phase1
+#######################################################
+
+[gcode_shell_command resonaces_y_mcmrt1]
+command: sh /home/biqu/printer_data/config/0_Xplorer/.8_Scripts/resonances_Y_mcmrt1.sh
+timeout: 80
+
 # Flash xplorer MCU Ext BTT Pico
 #######################################################
 

--- a/01_Default_CFG/Xp_Xplorer_Vars.cfg
+++ b/01_Default_CFG/Xp_Xplorer_Vars.cfg
@@ -26,6 +26,14 @@ variable_res_ymicp2e:   210    # Y coordinate input shaper calibration for the C
 variable_res_xmicpdg:     210    # X coordinate input shaper calibration for the Copy/Mirror Mode Dual Gantry
 variable_res_y1micp4e:  280    # Y coordinate input shaper calibration for the Copy/Mirror IQEX Gantry 1
 variable_res_y2micp4e:  350    # Y coordinate input shaper calibration for the Copy/Mirror IQEX Gantry 2
+variable_res_xmccpt0:   110    # X coordinate input shaper calibration for Multicolor Copy Phase0
+variable_res_ymccpt0:   350    # Y coordinate input shaper calibration for Multicolor Copy Phase0
+variable_res_xmccpt1:   110    # X coordinate input shaper calibration for Multicolor Copy Phase1
+variable_res_ymccpt1:   57.5   # Y coordinate input shaper calibration for Multicolor Copy Phase1
+variable_res_xmcmrt0:   110    # X coordinate input shaper calibration for Multicolor Mirror Phase0
+variable_res_ymcmrt0:   350    # Y coordinate input shaper calibration for Multicolor Mirror Phase0
+variable_res_xmcmrt1:   110    # X coordinate input shaper calibration for Multicolor Mirror Phase1
+variable_res_ymcmrt1:   57.5   # Y coordinate input shaper calibration for Multicolor Mirror Phase1
 variable_sp_pmode:      8000   # Speed for printheads when changing printing modes
 variable_calp_x:      177.5    # X pos nozzle Probe
 variable_calp_y:        406    # Y pos nozzle Probe


### PR DESCRIPTION
## Summary

Backports multicolor print mode support from the custom formbotXplorer firmware to the stock UpdateManager config, adding pmode 5 (MULTICOLOR_COPY01) and pmode 6 (MULTICOLOR_MIRROR01) for IQEX dual-extruder multicolor printing.

## Changes

### New print modes (pmode 5/6)
- `ACTIVATE_MULTICOLOR_COPY_MODE01` — copies T0 onto T1 with multicolor resonance shapers applied
- `ACTIVATE_MULTICOLOR_MIRROR_MODE01` — mirrors T0 onto T1 with multicolor resonance shapers applied
- Both include `G28 Y` to reset dual carriage Y after homing, matching formbotXplorer behavior

### Toolchange helpers
- `_MC_TOOL0` / `_MC_TOOL1` — multicolor-aware tool activation that parks inactive extruders and applies the correct per-tool shapers
- `_MC_CALIBRATE_PARK_INACTIVES` — parks inactive tools while keeping the active one for retraction
- `_RETRACT_IF_PRINTING` — shared base macro that conditionally retracts while printing/paused

### PAUSE / RESUME dual carriage state
- PAUSE now saves dual carriage state (`SAVE_DUAL_CARRIAGE_STATE NAME=PAUSE_DC`) before `BASE_PAUSE`
- RESUME restores it (`RESTORE_DUAL_CARRIAGE_STATE NAME=PAUSE_DC MOVE=0`) before the final state restore, preventing XY double-move after `G28 Y` in the pause park sequence

### Resonance calibration
- 8 new macros for X/Y resonance sweep on multicolor copy/mirror phases 0 and 1
- 8 new `gcode_shell_command` entries referencing the shell scripts
- 8 new shell scripts in `.8_Scripts/` that parse calibration output and write `shaper_type_xmccpt0`, `shaper_freq_xmccpt0`, etc. into `variables.cfg`
- `RESONANCE_CALIBRATION_IQEX` now chains all 8 multicolor resonance macros, so `Printer_Calibrate` runs a complete suite covering stock single-tool, IDEX, IQEX copy/mirror, and multicolor copy/mirror phases

### Variables
- 8 new calibration coordinates in `Xp_Xplorer_Vars.cfg` for multicolor copy/mirror X/Y shaper positions

## Files modified
- `01_Default_CFG/Xp_Xplorer_Vars.cfg` — 8 new shaper variable definitions
- `01_Default_CFG/Xp_Macros_Base.cfg` — `_RETRACT_IF_PRINTING` helper
- `01_Default_CFG/Xp_V1.1_Macros_IQEX.cfg` — activation macros, toolchange helpers, resonance calib, PAUSE/RESUME fix, SET_PRINT_MODE/START_PRINTING_MODE extensions
- `01_Default_CFG/Xp_V1.1_Shell_Commands_IQEX.cfg` — 8 new shell command entries
- `.8_Scripts/` — 8 new resonance shell scripts

## Stock compatibility
Existing single-tool, IDEX COPY01/MIRROR01, and 4-tool COPY0123/MIRROR0123 modes are unchanged. All multicolor logic is additive and gated behind the new pmode values.